### PR TITLE
Remove padding to show content at full page

### DIFF
--- a/backend/src/page.html
+++ b/backend/src/page.html
@@ -5,43 +5,19 @@
     <title>RMStream</title>
     <style>
         body {
-            margin: 0px;
-            padding: 10px;
-            width: calc(100vw - 20px);
-            height: calc(100vh - 20px);
+            margin: 0;
+            padding: 0;
+            width: 100vw;
+            height: 100vh;
             background: #f0f0f0;
-            display: flex;
-            justify-content: center;
-            align-content: center;
+            overflow: hidden;
         }
 
         canvas {
-            object-fit: contain;
+            position: absolute;
+            top: 50%;
+            left: 50%;
             transition: transform 0.3s ease;
-        }
-
-        canvas[data-rot='0'],
-        canvas[data-rot='180'] {
-            max-width: 100vw;
-            max-height: 100vh;
-        }
-
-        canvas[data-rot='90'],
-        canvas[data-rot='270'] {
-            max-width: 100vh;
-            max-height: 100vw;
-        }
-
-        canvas[data-rot='90'] {
-            transform: rotate(90deg);
-        }
-
-        canvas[data-rot='180'] {
-            transform: rotate(180deg);
-        }
-
-        canvas[data-rot='270'] {
-            transform: rotate(270deg);
         }
 
         #pointer {
@@ -119,16 +95,27 @@
         </div>
     </div>
 
-    <canvas id='root' data-rot='0' src='#' width="1624" height="2154"></canvas>
+    <canvas id='root' width="1624" height="2154"></canvas>
     <span id='pointer' style='display: none;'></span>
 
     <script>
         let rotation = 0;
         let cursorEnabled = true;
 
+        function fitCanvas() {
+            if (!width || !height) return;
+            const isLandscape = rotation === 90 || rotation === 270;
+            const visualW = isLandscape ? height : width;
+            const visualH = isLandscape ? width : height;
+            const scale = Math.min(window.innerWidth / visualW, window.innerHeight / visualH);
+            root.style.width = (width * scale) + 'px';
+            root.style.height = (height * scale) + 'px';
+            root.style.transform = `translate(-50%, -50%) rotate(${rotation}deg)`;
+        }
+
         function rotateImage() {
             rotation = (rotation + 90) % 360;
-            root.setAttribute('data-rot', rotation);
+            fitCanvas();
         }
 
         function toggleCursor() {
@@ -239,6 +226,8 @@
             context.putImageData(new ImageData(imageData, width, height), 0, 0);
         }
 
+        window.addEventListener('resize', fitCanvas);
+
         window.onload = () => {
             const webSocket = new WebSocket("/ws");
             webSocket.onclose = () => {
@@ -253,6 +242,7 @@
                     height = i32(5);
                     root.width = width;
                     root.height = height;
+                    fitCanvas();
                 } else if(data[0] == 1) {
                     await handleDeltas(data.slice(1));
                 } else if(data[0] == 2) {


### PR DESCRIPTION
Fixed the html page so that the content of the remarkable is showed at full width.
Especially relevant in landscape mode.

Now this is possible:
<img width="3748" height="2106" alt="image" src="https://github.com/user-attachments/assets/ae3994a0-8f71-4340-9dcc-07ee44cb992c" />